### PR TITLE
gemspec: Be explicit about 0 executables

### DIFF
--- a/navigable.gemspec
+++ b/navigable.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features|assets)/}) }
   end
   spec.bindir        = "exe"
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.executables   = []
   spec.require_paths = ["lib"]
 
   spec.add_dependency "concurrent-ruby", "~> 1.1.7"


### PR DESCRIPTION
👋 Hi! This PR tries to simplify the gemspec for the reader: the gem ships 0 executables, and can be explicit about this, by setting the list of executables to the empty list.